### PR TITLE
parser: Refactor Expression data

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,11 @@
+//--------------------------------------------------
+// Macros
+//--------------------------------------------------
+
+#[macro_export]
+macro_rules! index_struct {
+    ($i:ident) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub struct $i(usize);
+    };
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 #![feature(if_let_guard)]
+#[macro_use]
 
 mod lexer;
 mod parser;
 mod util;
 mod datastructure;
+mod macros;
 
 use lexer::Lexer;
 use parser::Parser;


### PR DESCRIPTION
This removes ExpressionAtoms and their IDs as the concept will not be relevant outside of a parsing context.
Furthermore, it moves the Expression vector into its own data struct (that will contain more data in the future) so we can pass on relevant data to the typechecker later.